### PR TITLE
fixes an issue where you could not supply quoted args to --blast_options

### DIFF
--- a/bio_pieces/parallel_blast.py
+++ b/bio_pieces/parallel_blast.py
@@ -160,7 +160,6 @@ def run(cmd, *args, **kwargs):
     args_str = ' '.join(args)
     print("[cmd] {0} {1} {2}".format(cmd._path, args_str, kwargs_str))
     try:
-        print(args)
         p = cmd(*args, **kwargs)
         print(p)
     except sh.ErrorReturnCode as e:
@@ -232,7 +231,6 @@ def generate_sshlogins(ninst=None):
 
 def main():
     args = parse_args()
-    print(args)
     assert exists(args.inputfasta), '[error] {0} does not exist'.format(args.inputfasta)
     if args.blast_exe == 'diamond':
         parallel_diamond(

--- a/bio_pieces/parallel_blast.py
+++ b/bio_pieces/parallel_blast.py
@@ -17,7 +17,7 @@ STATIC_BLAST_ARGS = [
 
 # Users cannot have these in the other args passed
 STATIC_DIAMOND_ARGS = [
-    '-t', '--threads', '-d', '--db', '-q', '--query', '--daa', '-a'
+    '-p', '--threads', '-d', '--db', '-q', '--query', '--daa', '-a'
 ]
 
 def parse_args():

--- a/bio_pieces/parallel_blast.py
+++ b/bio_pieces/parallel_blast.py
@@ -80,7 +80,7 @@ def parallel_blast(inputfile, outfile, ninst, db, blasttype, task, blastoptions)
         raise ValueError("{0} is not in your path(Maybe not installed?)".format(
             blasttype
         ))
-    args = ['-u', '--pipe', '--block', '100k', '--recstart', '>']
+    args = ['-u', '--pipe', '--block', '10', '--recstart', '>']
     args += generate_sshlogins(ninst)
     if task is not None:
         blast_cmd += ['-task', task]

--- a/bio_pieces/parallel_blast.py
+++ b/bio_pieces/parallel_blast.py
@@ -20,6 +20,9 @@ STATIC_DIAMOND_ARGS = [
     '-p', '--threads', '-d', '--db', '-q', '--query', '--daa', '-a'
 ]
 
+# Static args for parallel
+PARALLEL_ARGS = ['-u', '--pipe', '--cat', '--block', '10', '--recstart', '>', '--round-robin']
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -74,19 +77,19 @@ def parallel_blast(inputfile, outfile, ninst, db, blasttype, task, blastoptions)
     if set(STATIC_BLAST_ARGS).intersection(shlex.split(blastoptions)):
         raise ValueError("You cannot supply any of the arguments inside of {0} as" \
             " optional arguments to blast".format(STATIC_BLAST_ARGS))
+    args = list(PARALLEL_ARGS)
+    args += generate_sshlogins(ninst)
     blast_path = sh.which(blasttype)
     blast_cmd = [blast_path]
     if blast_path is None:
         raise ValueError("{0} is not in your path(Maybe not installed?)".format(
             blasttype
         ))
-    args = ['-u', '--pipe', '--block', '10', '--recstart', '>']
-    args += generate_sshlogins(ninst)
     if task is not None:
         blast_cmd += ['-task', task]
     blast_cmd += ['-db', db,]
     blast_cmd += [blastoptions]
-    blast_cmd += ['-query', '-']
+    blast_cmd += ['-query', '{}']
     args += [' '.join(blast_cmd)]
     cmd = sh.Command('parallel')
     run(cmd, *args, _in=open(inputfile), _out=open(outfile,'w'))
@@ -132,7 +135,7 @@ def parallel_diamond(inputfile, outfile, ninst, db, task, diamondoptions):
         '--daa', '{}.{#}', ';', dmnd_path, 'view', '--daa', '{}.{#}.daa'
     ]
     if len(sshlogins) > 2:
-        args = ['-u', '--pipe', '--block', '10', '--recstart', '>', '--cat']
+        args = list(PARALLEL_ARGS)
         args += sshlogins
         diamond_cmd_str = ' '.join(diamond_cmd) + diamondoptions
         args += [diamond_cmd_str]

--- a/tests/test_parallel_blast.py
+++ b/tests/test_parallel_blast.py
@@ -138,7 +138,7 @@ class TestParallelBlast(MockSH):
             self.infile, self.outfile, 5, '/path/db/nt', 'blastn', 'megablast',
             '-evalue 0.01 -otherblast arg'
         )
-        r = self.mock_sh_cmd.return_value.call_args[0]
+        r = self.mock_sh_cmd.return_value.call_args[0][-1]
         self.assertIn('/path/to/blastn', r)
         self.assertIn('-task', r)
         self.assertIn('megablast', r)
@@ -149,7 +149,7 @@ class TestParallelBlast(MockSH):
             self.infile, self.outfile, 5, '/path/db/nt', 'diamond', None,
             '-evalue 0.01 -otherblast arg'
         )
-        r = self.mock_sh_cmd.return_value.call_args[0]
+        r = self.mock_sh_cmd.return_value.call_args[0][-1]
         self.assertIn('/path/to/diamond', r)
         self.assertNotIn('-task', r)
 
@@ -159,7 +159,7 @@ class TestParallelBlast(MockSH):
             self.infile, self.outfile, 5, '/path/db/nt', 'blastx', None,
             '-evalue 0.01 -otherblast arg'
         )
-        r = self.mock_sh_cmd.return_value.call_args[0]
+        r = self.mock_sh_cmd.return_value.call_args[0][-1]
         self.assertIn('/path/to/blastx', r)
         self.assertNotIn('-task', r)
 
@@ -171,7 +171,7 @@ class TestParallelBlast(MockSH):
         )
         self.mock_sh_cmd.assert_called_once_with('parallel')
         r = self.mock_sh_cmd.return_value.call_args
-        blastcmd = r[0]
+        blastcmd = r[0][-1]
         print(r[0])
         self.assertIn('-db', blastcmd)
         self.assertIn('/path/db/nt', blastcmd)


### PR DESCRIPTION
Apparently shlex.split was stripping quotes where they may be needed

Since parallel can accept a quoted command I switched to that instead

Prior to this if you tried to supply ``--blast_options "-outfmt \"6 qseq sseq....\""`` the quotes around ``6 qseq sseq...`` would be stripped and blast would report an error